### PR TITLE
test 1é

### DIFF
--- a/project-test-image/app/page.tsx
+++ b/project-test-image/app/page.tsx
@@ -4,13 +4,13 @@ import Eyck from "./VanEyck.jpg";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <div className="flex justify-between overflow-x-auto">
-        <div className="w-full h-auto relative rounded-md overflow-hidden">
-          <Image src={Frago} alt="" fill={true} className="objet-cover" />
+    <main className="w-full">
+      <div className="flex flex-row">
+        <div className="w-[416px] h-[740px] bg-blue-400">
+          <Image src={Frago} alt="" className="object-cover" />
         </div>
-        <div className="w-full h-auto relative rounded-md overflow-hidden">
-          <Image src={Eyck} alt="" fill={true} className="objet-cover" />
+        <div className="w-[416px] h-[740px] bg-red-500">
+          <Image src={Eyck} alt="" className="w-full h-auto object-cover" />
         </div>
       </div>
     </main>


### PR DESCRIPTION
<img width="1108" alt="Capture d’écran 2023-05-19 à 15 49 53" src="https://github.com/Luzzzi/test-image/assets/80071685/a214da06-a32c-4bc7-935e-77ef7c970a7a">


J'ai retiré `fill=true` qui est normalement sur mes images dans wwoof, du coup je suppose que les images ont leur taille d'origine en revanche en bleu et rouge les parents ont la taille donnée, par contre le `object-cover` ne fait rien alors que je pensais qu'il devrait faire en sorte que l'image couvre l'intégralité de son parent 

"Alternatively, object-fit: "cover" will cause the image to fill the entire container and be cropped to preserve aspect ratio." cf doc de Next.Js 