### PR TITLE
Test 2

### DIFF
--- a/project-test-image/app/page.tsx
+++ b/project-test-image/app/page.tsx
@@ -7,10 +7,10 @@ export default function Home() {
     <main className="w-full">
       <div className="flex flex-row">
         <div className="w-[416px] h-[740px] bg-blue-400">
-          <Image src={Frago} alt="" className="object-cover" />
+          <Image src={Frago} alt="" fill={true} className="object-cover" />
         </div>
         <div className="w-[416px] h-[740px] bg-red-500">
-          <Image src={Eyck} alt="" className="w-full h-auto object-cover" />
+          <Image src={Eyck} alt="" fill={true} className="object-cover" />
         </div>
       </div>
     </main>

--- a/project-test-image/app/page.tsx
+++ b/project-test-image/app/page.tsx
@@ -4,13 +4,13 @@ import Eyck from "./VanEyck.jpg";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <div className="flex justify-between overflow-x-auto">
-        <div className="w-full h-auto relative rounded-md overflow-hidden">
-          <Image src={Frago} alt="" fill={true} className="objet-cover" />
+    <main className="w-full">
+      <div className="flex flex-row">
+        <div className="w-[416px] h-[740px] bg-blue-400">
+          <Image src={Frago} alt="" className="object-cover" />
         </div>
-        <div className="w-full h-auto relative rounded-md overflow-hidden">
-          <Image src={Eyck} alt="" fill={true} className="objet-cover" />
+        <div className="w-[416px] h-[740px] bg-red-500">
+          <Image src={Eyck} alt="" className="w-full h-auto object-cover" />
         </div>
       </div>
     </main>


### PR DESCRIPTION
<img width="1103" alt="Capture d’écran 2023-05-19 à 15 50 56" src="https://github.com/Luzzzi/test-image/assets/80071685/2a09c9b9-839e-4f13-8136-448e20f10837">


Là c'est particulièrement un mystère pour moi et ça se rapproche de mon cas d'usage dans wwoof, sauf que j'ai `relative` en plus sur le parent. Je fais docn ce que dit la doc à savoir mettre fill à true ce qui devrait faire que ça prends la taille du parent et là je définis la taille du parent. 
Quand je suis dans wwoof, je me retrouve quand même avec des images avec deux tailles différentes ou des images déformées 

La deuxième image prends la pleine page
Alors que dnas la doc à propos de `fill` : "A boolean that causes the image to fill the parent element instead of setting [width](https://nextjs.org/docs/pages/api-reference/components/image#width) and [height](https://nextjs.org/docs/pages/api-reference/components/image#height)."  